### PR TITLE
Fix stale versions by reading maven-metadata.xml instead of the Solr index

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,7 +196,7 @@ const result2 = await mcpClient.callTool("maven-deps-server", "check_maven_versi
 
 ### list_maven_versions
 
-Lists Maven dependency versions sorted by last updated date (most recent first) with optional pre-release filtering and depth control.
+Lists Maven dependency versions in deploy order, most recent first, with optional pre-release filtering and depth control. Output is one version per line.
 
 **Input Schema:**
 ```json
@@ -229,7 +229,7 @@ Lists Maven dependency versions sorted by last updated date (most recent first) 
 const result1 = await mcpClient.callTool("maven-deps-server", "list_maven_versions", {
   dependency: "org.springframework:spring-core"
 });
-// Returns only stable versions: "6.2.8 (2025-06-12)\n6.1.21 (2025-06-12)\n6.2.7 (2025-05-15)\n..."
+// Returns only stable versions: "6.2.8\n6.1.21\n6.2.7\n..."
 
 // Get last 5 versions including pre-releases
 const result2 = await mcpClient.callTool("maven-deps-server", "list_maven_versions", {
@@ -237,15 +237,15 @@ const result2 = await mcpClient.callTool("maven-deps-server", "list_maven_versio
   depth: 5,
   excludePreReleases: false
 });
-// Returns: "7.0.0-M6 (2025-06-12)\n6.2.8 (2025-06-12)\n6.1.21 (2025-06-12)\n7.0.0-M5 (2025-05-15)\n6.2.7 (2025-05-15)"
+// Returns: "7.0.0-M6\n6.2.8\n6.1.21\n7.0.0-M5\n6.2.7"
 ```
 
 ## Implementation Details
 
-- Uses Maven Central's REST API to fetch dependency information
+- Queries `maven-metadata.xml` on Maven Central directly (`https://repo1.maven.org/maven2/<g>/<a>/maven-metadata.xml`) — the authoritative file Maven and Gradle themselves consult during dependency resolution. It updates within seconds of a deploy, so results are never stale.
 - Supports full Maven coordinates (groupId:artifactId:version:packaging:classifier)
 - Intelligent pre-release detection using regex pattern matching
-- Returns versions sorted by their last updated timestamp in Maven Central
+- Returns versions in deploy order (most recent first) as recorded in `maven-metadata.xml`
 - Includes error handling for invalid dependencies and API issues
 - Returns clean, parseable version strings for valid dependencies
 - Provides boolean responses for version existence checks

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,17 +1,18 @@
 {
   "name": "mcp-maven-deps",
-  "version": "0.1.2",
+  "version": "0.1.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mcp-maven-deps",
-      "version": "0.1.2",
+      "version": "0.1.7",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "1.10.2",
         "axios": "^1.7.9",
-        "express": "^4.18.3"
+        "express": "^4.18.3",
+        "fast-xml-parser": "^4.5.0"
       },
       "bin": {
         "mcp-maven-deps": "build/index.js"
@@ -806,6 +807,24 @@
         "express": "^4.11 || 5 || ^5.0.0-beta.1"
       }
     },
+    "node_modules/fast-xml-parser": {
+      "version": "4.5.6",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.5.6.tgz",
+      "integrity": "sha512-Yd4vkROfJf8AuJrDIVMVmYfULKmIJszVsMv7Vo71aocsKgFxpdlpSHXSaInvyYfgw2PRuObQSW2GFpVMUjxu9A==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "strnum": "^1.0.5"
+      },
+      "bin": {
+        "fxparser": "src/cli/cli.js"
+      }
+    },
     "node_modules/finalhandler": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.3.1.tgz",
@@ -1465,6 +1484,18 @@
       "engines": {
         "node": ">= 0.8"
       }
+    },
+    "node_modules/strnum": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-1.1.2.tgz",
+      "integrity": "sha512-vrN+B7DBIoTTZjnPNewwhx6cBA/H+IS7rfW68n7XxC1y7uoiGQBxaKzqucGUgavX15dJgiGztLJ8vxuEzwqBdA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/toidentifier": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
   "dependencies": {
     "@modelcontextprotocol/sdk": "1.10.2",
     "axios": "^1.7.9",
-    "express": "^4.18.3"
+    "express": "^4.18.3",
+    "fast-xml-parser": "^4.5.0"
   },
   "devDependencies": {
     "@types/express": "^4.17.21",

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,19 +11,16 @@ import {
   McpError,
 } from '@modelcontextprotocol/sdk/types.js';
 import axios from 'axios';
+import { XMLParser } from 'fast-xml-parser';
 
-interface MavenSearchResponse {
-  response: {
-    docs: Array<{
-      id: string;
-      g: string; // groupId
-      a: string; // artifactId
-      v: string; // version
-      p?: string; // packaging
-      timestamp: number;
-    }>;
-  };
-}
+// Data source: the authoritative maven-metadata.xml on Maven Central, not the
+// search.maven.org Solr index. The Solr index has been observed to lag by up
+// to a year (see issue #12) because it's updated by an async indexer that can
+// stall. maven-metadata.xml is the file Maven and Gradle themselves consult
+// during dependency resolution — it updates within seconds of a deploy and
+// exposes explicit <release> / <latest> / <versions> elements, so client-side
+// version sorting (the root cause of the stale-data complaints) is no longer
+// needed.
 
 interface MavenCoordinate {
   groupId: string;
@@ -31,6 +28,14 @@ interface MavenCoordinate {
   version?: string;
   packaging?: string;
   classifier?: string;
+}
+
+// Shape of the subset of maven-metadata.xml we consume.
+interface MavenMetadata {
+  latest?: string;
+  release?: string;
+  versions: string[]; // in deploy order, oldest first
+  lastUpdated?: string;
 }
 
 const parseMavenCoordinate = (dependency: string): MavenCoordinate => {
@@ -57,13 +62,6 @@ const isPreReleaseVersion = (version: string): boolean => {
   return preReleasePattern.test(version);
 };
 
-const isValidMavenArgs = (
-  args: any
-): args is { dependency: string } =>
-  typeof args === 'object' &&
-  args !== null &&
-  typeof args.dependency === 'string';
-
 const isValidVersionCheckArgs = (
   args: any
 ): args is { dependency: string; version?: string } =>
@@ -89,6 +87,22 @@ const isValidListVersionsArgs = (
   (args.depth === undefined || (typeof args.depth === 'number' && args.depth > 0)) &&
   (args.excludePreReleases === undefined || typeof args.excludePreReleases === 'boolean');
 
+const METADATA_BASE = 'https://repo1.maven.org/maven2';
+
+const metadataPath = (coord: MavenCoordinate): string => {
+  const g = coord.groupId.split('.').map(encodeURIComponent).join('/');
+  const a = encodeURIComponent(coord.artifactId);
+  return `/${g}/${a}/maven-metadata.xml`;
+};
+
+const coordLabel = (coord: MavenCoordinate): string =>
+  `${coord.groupId}:${coord.artifactId}${coord.packaging ? ':' + coord.packaging : ''}`;
+
+const xmlParser = new XMLParser({
+  ignoreAttributes: true,
+  parseTagValue: false, // keep version strings as-is; don't coerce "1.0" to a number
+});
+
 class MavenDepsServer {
   private server: Server;
   private axiosInstance;
@@ -107,17 +121,45 @@ class MavenDepsServer {
     );
 
     this.axiosInstance = axios.create({
-      baseURL: 'https://search.maven.org/solrsearch/select',
+      baseURL: METADATA_BASE,
+      responseType: 'text',
+      // fast-xml-parser needs the raw string; suppress axios' auto JSON parse.
+      transformResponse: (data) => data,
     });
 
     this.setupToolHandlers();
-    
+
     // Error handling
     this.server.onerror = (error) => console.error('[MCP Error]', error);
     process.on('SIGINT', async () => {
       await this.server.close();
       process.exit(0);
     });
+  }
+
+  private async fetchMetadata(coord: MavenCoordinate): Promise<MavenMetadata | null> {
+    try {
+      const response = await this.axiosInstance.get<string>(metadataPath(coord));
+      const parsed = xmlParser.parse(response.data);
+      const versioning = parsed?.metadata?.versioning ?? {};
+      const rawVersions = versioning.versions?.version;
+      const versions: string[] = Array.isArray(rawVersions)
+        ? rawVersions
+        : rawVersions
+          ? [rawVersions]
+          : [];
+      return {
+        latest: versioning.latest,
+        release: versioning.release,
+        versions,
+        lastUpdated: versioning.lastUpdated,
+      };
+    } catch (error) {
+      if (axios.isAxiosError(error) && error.response?.status === 404) {
+        return null;
+      }
+      throw error;
+    }
   }
 
   private setupToolHandlers() {
@@ -162,7 +204,7 @@ class MavenDepsServer {
         },
         {
           name: 'list_maven_versions',
-          description: 'List Maven dependency versions sorted by last updated date (most recent first)',
+          description: 'List Maven dependency versions in deploy order (most recent first)',
           inputSchema: {
             type: 'object',
             properties: {
@@ -205,6 +247,33 @@ class MavenDepsServer {
     });
   }
 
+  private notFound(coord: MavenCoordinate) {
+    return {
+      content: [
+        {
+          type: 'text',
+          text: `No Maven dependency found for ${coordLabel(coord)}`,
+        },
+      ],
+      isError: true,
+    };
+  }
+
+  private mavenError(error: unknown) {
+    if (axios.isAxiosError(error)) {
+      return {
+        content: [
+          {
+            type: 'text',
+            text: `Maven Central API error: ${error.response?.statusText ?? error.message}`,
+          },
+        ],
+        isError: true,
+      };
+    }
+    throw error;
+  }
+
   private async handleGetLatestRelease(args: unknown) {
     if (!isValidReleaseArgs(args)) {
       throw new McpError(
@@ -217,43 +286,23 @@ class MavenDepsServer {
     const excludePreReleases = args.excludePreReleases ?? true; // Default to true
 
     try {
-      let query = `g:"${coord.groupId}" AND a:"${coord.artifactId}"`;
-      if (coord.packaging) {
-        query += ` AND p:"${coord.packaging}"`;
+      const meta = await this.fetchMetadata(coord);
+      if (!meta || meta.versions.length === 0) {
+        return this.notFound(coord);
       }
 
-      const response = await this.axiosInstance.get<MavenSearchResponse>('', {
-        params: {
-          q: query,
-          core: 'gav',
-          rows: 100, // Get more results for filtering
-          wt: 'json',
-          sort: 'timestamp desc',
-        },
-      });
-
-      if (!response.data.response.docs.length) {
-        return {
-          content: [
-            {
-              type: 'text',
-              text: `No Maven dependency found for ${coord.groupId}:${coord.artifactId}${coord.packaging ? ':' + coord.packaging : ''}`,
-            },
-          ],
-          isError: true,
-        };
-      }
-
-      // Filter versions if needed
-      let versions = response.data.response.docs;
+      // <versions> is oldest-first; reverse for newest deploy first. We always
+      // filter client-side rather than trusting <release>, since <release> can
+      // point at a version we classify as a pre-release qualifier.
+      let candidates = [...meta.versions].reverse();
       if (excludePreReleases) {
-        versions = versions.filter(doc => !isPreReleaseVersion(doc.v));
-        if (versions.length === 0) {
+        candidates = candidates.filter(v => !isPreReleaseVersion(v));
+        if (candidates.length === 0) {
           return {
             content: [
               {
                 type: 'text',
-                text: `No stable releases found for ${coord.groupId}:${coord.artifactId}${coord.packaging ? ':' + coord.packaging : ''}. All available versions are pre-releases.`,
+                text: `No stable releases found for ${coordLabel(coord)}. All available versions are pre-releases.`,
               },
             ],
             isError: true,
@@ -261,31 +310,16 @@ class MavenDepsServer {
         }
       }
 
-      // Return the most recently updated version (after filtering)
-      const latestVersion = versions[0].v;
       return {
         content: [
           {
             type: 'text',
-            text: latestVersion,
+            text: candidates[0],
           },
         ],
       };
     } catch (error) {
-      if (axios.isAxiosError(error)) {
-        return {
-          content: [
-            {
-              type: 'text',
-              text: `Maven Central API error: ${
-                error.response?.data?.error?.msg ?? error.message
-              }`,
-            },
-          ],
-          isError: true,
-        };
-      }
-      throw error;
+      return this.mavenError(error);
     }
   }
 
@@ -300,7 +334,7 @@ class MavenDepsServer {
     const coord = parseMavenCoordinate(args.dependency);
     // Use version from coordinate if available, otherwise use the version parameter
     const version = coord.version || args.version;
-    
+
     if (!version) {
       throw new McpError(
         ErrorCode.InvalidParams,
@@ -309,21 +343,8 @@ class MavenDepsServer {
     }
 
     try {
-      let query = `g:"${coord.groupId}" AND a:"${coord.artifactId}" AND v:"${version}"`;
-      if (coord.packaging) {
-        query += ` AND p:"${coord.packaging}"`;
-      }
-
-      const response = await this.axiosInstance.get<MavenSearchResponse>('', {
-        params: {
-          q: query,
-          core: 'gav',
-          rows: 1,
-          wt: 'json',
-        },
-      });
-
-      const exists = response.data.response.docs.length > 0;
+      const meta = await this.fetchMetadata(coord);
+      const exists = meta !== null && meta.versions.includes(version);
       return {
         content: [
           {
@@ -333,20 +354,7 @@ class MavenDepsServer {
         ],
       };
     } catch (error) {
-      if (axios.isAxiosError(error)) {
-        return {
-          content: [
-            {
-              type: 'text',
-              text: `Maven Central API error: ${
-                error.response?.data?.error?.msg ?? error.message
-              }`,
-            },
-          ],
-          isError: true,
-        };
-      }
-      throw error;
+      return this.mavenError(error);
     }
   }
 
@@ -363,87 +371,50 @@ class MavenDepsServer {
     const excludePreReleases = args.excludePreReleases ?? true; // Default to true
 
     try {
-      let query = `g:"${coord.groupId}" AND a:"${coord.artifactId}"`;
-      if (coord.packaging) {
-        query += ` AND p:"${coord.packaging}"`;
+      const meta = await this.fetchMetadata(coord);
+      if (!meta || meta.versions.length === 0) {
+        return this.notFound(coord);
       }
 
-      const response = await this.axiosInstance.get<MavenSearchResponse>('', {
-        params: {
-          q: query,
-          core: 'gav',
-          rows: 100,
-          wt: 'json',
-          sort: 'timestamp desc',
-        },
-      });
-
-      if (!response.data.response.docs.length) {
-        return {
-          content: [
-            {
-              type: 'text',
-              text: `No Maven dependency found for ${coord.groupId}:${coord.artifactId}${coord.packaging ? ':' + coord.packaging : ''}`,
-            },
-          ],
-          isError: true,
-        };
-      }
-
-      // Filter versions if needed
-      let filteredDocs = response.data.response.docs;
+      // <versions> is oldest-first; reverse for newest-first, then optionally
+      // filter. maven-metadata.xml has no per-version timestamps, so output is
+      // one version per line (previously "X.Y.Z (YYYY-MM-DD)").
+      let versions = [...meta.versions].reverse();
       if (excludePreReleases) {
-        filteredDocs = filteredDocs.filter(doc => !isPreReleaseVersion(doc.v));
+        versions = versions.filter(v => !isPreReleaseVersion(v));
       }
 
-      if (filteredDocs.length === 0) {
+      if (versions.length === 0) {
         return {
           content: [
             {
               type: 'text',
-              text: excludePreReleases 
-                ? `No stable releases found for ${coord.groupId}:${coord.artifactId}${coord.packaging ? ':' + coord.packaging : ''}. All available versions are pre-releases.`
-                : `No Maven dependency found for ${coord.groupId}:${coord.artifactId}${coord.packaging ? ':' + coord.packaging : ''}`,
+              text: excludePreReleases
+                ? `No stable releases found for ${coordLabel(coord)}. All available versions are pre-releases.`
+                : `No Maven dependency found for ${coordLabel(coord)}`,
             },
           ],
           isError: true,
         };
       }
 
-      const versions = filteredDocs
-        .sort((a, b) => b.timestamp - a.timestamp)
-        .slice(0, depth)
-        .map(doc => `${doc.v} (${new Date(doc.timestamp).toISOString().split('T')[0]})`);
-
+      const out = versions.slice(0, depth).join('\n');
       return {
         content: [
           {
             type: 'text',
-            text: versions.join('\n'),
+            text: out,
           },
         ],
       };
     } catch (error) {
-      if (axios.isAxiosError(error)) {
-        return {
-          content: [
-            {
-              type: 'text',
-              text: `Maven Central API error: ${
-                error.response?.data?.error?.msg ?? error.message
-              }`,
-            },
-          ],
-          isError: true,
-        };
-      }
-      throw error;
+      return this.mavenError(error);
     }
   }
 
   async run(opts?: { port?: number; host?: string }) {
     let transport: StdioServerTransport | SSEServerTransport | undefined;
-    
+
     if (opts?.port) {
       const app = express();
       const httpServer = createServer(app);

--- a/test-maven-server.js
+++ b/test-maven-server.js
@@ -1,13 +1,17 @@
 #!/usr/bin/env node
 
 import axios from 'axios';
+import { XMLParser } from 'fast-xml-parser';
 
-// Test configuration
+// Sanity test: probes Maven Central directly (not the MCP server) to verify
+// that maven-metadata.xml still returns fresh data for a few representative
+// artifacts. This is the same data source the MCP server consumes.
+
 const testDependencies = [
   {
     name: 'kafka-clients',
     dependency: 'org.apache.kafka:kafka-clients',
-    description: 'Should return the most recently updated version'
+    description: 'Should return the current release from maven-metadata.xml'
   },
   {
     name: 'google-api-services-drive',
@@ -21,92 +25,95 @@ const testDependencies = [
   }
 ];
 
-async function testMavenAPI() {
-  console.log('Testing Maven Central API directly...\n');
-  
+const parser = new XMLParser({ ignoreAttributes: true, parseTagValue: false });
+
+function metadataUrl(groupId, artifactId) {
+  const g = groupId.split('.').map(encodeURIComponent).join('/');
+  const a = encodeURIComponent(artifactId);
+  return `https://repo1.maven.org/maven2/${g}/${a}/maven-metadata.xml`;
+}
+
+async function fetchMetadata(groupId, artifactId) {
+  const response = await axios.get(metadataUrl(groupId, artifactId), { responseType: 'text', transformResponse: d => d });
+  const parsed = parser.parse(response.data);
+  const versioning = parsed?.metadata?.versioning ?? {};
+  const raw = versioning.versions?.version;
+  const versions = Array.isArray(raw) ? raw : raw ? [raw] : [];
+  return {
+    release: versioning.release,
+    latest: versioning.latest,
+    versions,
+    lastUpdated: versioning.lastUpdated,
+  };
+}
+
+async function testMavenMetadata() {
+  console.log('Testing Maven Central maven-metadata.xml directly...\n');
+
   for (const test of testDependencies) {
     console.log(`\nTesting ${test.name}:`);
     console.log(`Dependency: ${test.dependency}`);
     console.log(`Description: ${test.description}`);
-    
+
     try {
-      // Parse dependency
       const [groupId, artifactId] = test.dependency.split(':');
-      
-      // Test getting the most recently updated version
-      const response = await axios.get('https://search.maven.org/solrsearch/select', {
-        params: {
-          q: `g:"${groupId}" AND a:"${artifactId}"`,
-          core: 'gav',
-          rows: 5,
-          wt: 'json',
-          sort: 'timestamp desc'
-        }
-      });
-      
-      if (response.data.response.docs.length > 0) {
-        const mostRecent = response.data.response.docs[0];
-        console.log(`\nMost recently updated version: ${mostRecent.v}`);
-        console.log(`Last updated: ${new Date(mostRecent.timestamp).toISOString()}`);
-        
-        console.log('\nTop 5 versions by last updated date:');
-        response.data.response.docs.forEach((doc, index) => {
-          console.log(`${index + 1}. ${doc.v} - ${new Date(doc.timestamp).toISOString().split('T')[0]}`);
-        });
-      } else {
+      const meta = await fetchMetadata(groupId, artifactId);
+
+      if (meta.versions.length === 0) {
         console.log('No versions found!');
+        continue;
       }
-      
+
+      console.log(`\n<release>: ${meta.release ?? '(not present)'}`);
+      console.log(`<latest>:  ${meta.latest ?? '(not present)'}`);
+      console.log(`<lastUpdated>: ${meta.lastUpdated ?? '(not present)'}`);
+
+      console.log('\nTop 5 versions (newest deploy first):');
+      const newestFirst = [...meta.versions].reverse();
+      newestFirst.slice(0, 5).forEach((v, i) => {
+        console.log(`${i + 1}. ${v}`);
+      });
+
     } catch (error) {
       console.error(`Error testing ${test.name}:`, error.message);
     }
   }
-  
+
   console.log('\n\nSummary:');
-  console.log('The server now returns the most recently updated version, not necessarily the highest semantic version.');
-  console.log('Users who need specific versions can use list_maven_versions to see all versions sorted by update date.');
+  console.log('maven-metadata.xml is the authoritative source Maven/Gradle themselves use.');
+  console.log('It updates seconds after a deploy, so "latest" here is always current.');
 }
 
 // Test the pre-release filtering functionality
 async function testPreReleaseFiltering() {
   console.log('\n\n=== Testing Pre-release Filtering ===\n');
 
-  // Function to test if version is pre-release (same as in server)
   const isPreReleaseVersion = (version) => {
     const preReleasePattern = /-(alpha|a|beta|b|milestone|m|rc|cr|snapshot)/i;
     return preReleasePattern.test(version);
   };
 
-  // Test with Spring Core (has M6 milestone versions)
   console.log('Testing Spring Core pre-release filtering:');
   try {
-    const response = await axios.get('https://search.maven.org/solrsearch/select', {
-      params: {
-        q: 'g:"org.springframework" AND a:"spring-core"',
-        core: 'gav',
-        rows: 10,
-        wt: 'json',
-        sort: 'timestamp desc',
-      }
-    });
+    const meta = await fetchMetadata('org.springframework', 'spring-core');
+    const newestFirst = [...meta.versions].reverse();
 
-    if (response.data.response.docs.length > 0) {
-      console.log('\nAll versions (top 5):');
-      response.data.response.docs.slice(0, 5).forEach((doc, i) => {
-        const badge = isPreReleaseVersion(doc.v) ? ' [PRE-RELEASE]' : ' [STABLE]';
-        console.log(`${i + 1}. ${doc.v} (${new Date(doc.timestamp).toISOString().split('T')[0]})${badge}`);
+    if (newestFirst.length > 0) {
+      console.log('\nAll versions (top 5, newest deploy first):');
+      newestFirst.slice(0, 5).forEach((v, i) => {
+        const badge = isPreReleaseVersion(v) ? ' [PRE-RELEASE]' : ' [STABLE]';
+        console.log(`${i + 1}. ${v}${badge}`);
       });
 
-      // Filter stable versions
-      const stableVersions = response.data.response.docs.filter(doc => !isPreReleaseVersion(doc.v));
-      console.log(`\n✅ Latest stable release (filtered): ${stableVersions[0]?.v || 'None found'}`);
-      console.log(`⚠️  Latest overall (unfiltered): ${response.data.response.docs[0].v}`);
+      const stableVersions = newestFirst.filter(v => !isPreReleaseVersion(v));
+      console.log(`\nLatest stable release (filtered): ${stableVersions[0] ?? 'None found'}`);
+      console.log(`Latest overall (unfiltered):       ${newestFirst[0]}`);
+      console.log(`<release> from metadata.xml:       ${meta.release ?? '(not present)'}`);
     }
   } catch (error) {
     console.error('Error testing Spring Core:', error.message);
   }
 
-  // Test regex pattern
   console.log('\n=== Pre-release Pattern Tests ===');
   const versionTests = [
     { version: '7.0.0-M6', expected: true },
@@ -119,14 +126,13 @@ async function testPreReleaseFiltering() {
 
   versionTests.forEach(test => {
     const result = isPreReleaseVersion(test.version);
-    const status = result === test.expected ? '✅' : '❌';
+    const status = result === test.expected ? 'PASS' : 'FAIL';
     console.log(`${status} ${test.version} -> ${result}`);
   });
 }
 
-// Run both test suites
 async function runAllTests() {
-  await testMavenAPI();
+  await testMavenMetadata();
   await testPreReleaseFiltering();
 }
 


### PR DESCRIPTION
Closes #12.

## Why Solr keeps going stale

`search.maven.org/solrsearch/select` is asynchronously indexed and has stalled repeatedly — sometimes by more than a year. For some artifacts the top Solr result is simply absent from the index, so no amount of pagination, `rows=` widening, or re-sorting recovers it. Two examples at the time of this PR:

| Artifact | Solr `sort=timestamp desc, rows=100` top result | `maven-metadata.xml` `<release>` |
|---|---|---|
| `org.springframework.boot:spring-boot-gradle-plugin` | `3.5.3` (deployed 2025-06-20) | `4.0.6` (deployed 2026-04) |
| `com.vaadin:vaadin-core` | `23.5.17` (deployed 2025-05-14) | `25.1.3` (deployed 2026-04-22) |

The earlier Solr-endpoint swap (5509e4f, reverted in e376227) hit the same root cause — it's not a sort bug, the missing versions aren't indexed at all.

## The fix

Query the authoritative `maven-metadata.xml` at

```
https://repo1.maven.org/maven2/<g-with-slashes>/<a>/maven-metadata.xml
```

directly. This is the file Maven and Gradle themselves consult during dependency resolution, it updates within seconds of a deploy, and it exposes explicit `<release>` / `<latest>` / `<versions>` elements — so the client-side sort the previous code relied on is no longer necessary.

## What changed

- **`src/index.ts`** — swap axios baseURL to `repo1.maven.org/maven2`, add a `fetchMetadata()` helper that parses the XML with `fast-xml-parser`, rewrite the three handlers around it. Each handler now does essentially: fetch metadata → reverse versions → optionally filter pre-releases → slice to depth. SSE/HTTP transport, `--port` / `--host` CLI flags, error handling, pre-release detection, and all tool names / input schemas are **unchanged**.
- **`package.json`** — add `fast-xml-parser ^4.5.0`. `axios` and `express` stay.
- **`test-maven-server.js`** — point the sanity test at `maven-metadata.xml` too, so it exercises the same data source the server does.
- **`README.md`** — update the Implementation Details section and the `list_maven_versions` examples to reflect the new data source and output format.

## User-visible behavior change

`list_maven_versions` no longer appends a `(YYYY-MM-DD)` deploy date to each line — `maven-metadata.xml` doesn't carry per-version timestamps, and fetching them would require N extra requests per call. Versions still come out in deploy order, newest first. Everything else — tool names, argument schemas, return types, pre-release filtering, `depth`, and the boolean result of `check_maven_version_exists` — is identical.

## Verified end-to-end

Built locally (`npm install && npm run build`) and smoke-tested over stdio:

| Tool call | Result |
|---|---|
| `get_latest_release org.springframework.boot:spring-boot-gradle-plugin` | `4.0.6` (was `3.5.3` on `main`) |
| `list_maven_versions com.vaadin:vaadin-core` (depth=5) | `25.1.3 / 25.1.2 / 25.1.1 / 25.1.0 / 25.0.9` |
| `check_maven_version_exists org.springframework:spring-core 6.2.8` | `true` |

## Test plan

- [ ] `npm install && npm run build` succeeds
- [ ] `node test-maven-server.js` prints fresh `<release>` values for the three test dependencies
- [ ] MCP client sees the three tools with the same names/schemas as before
- [ ] `get_latest_release` and `list_maven_versions` return current versions for at least one artifact that was stuck on stale data before this PR (e.g. `org.springframework.boot:spring-boot-gradle-plugin`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)